### PR TITLE
fixed getSignerAddress return value format

### DIFF
--- a/wrapper/deployment.json
+++ b/wrapper/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmfXVjDkyRWzBvpRMKpTHE7Cu1gSvUfQJQwfKPUCubspnW"
+        "result": "wrap://ipfs/Qmf38QJV1kS2qd1DwLB5zvcDXmf2D8EdrzdBTc4oYbPKeJ"
       }
     ]
   }

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -55,7 +55,7 @@ pub fn estimate_eip1559_fees(args: wrap::ArgsEstimateEip1559Fees) -> wrap::Eip15
 
 pub fn get_signer_address(args: wrap::ArgsGetSignerAddress) -> String {
     let address = PolywrapSigner::new(&args.connection).address();
-    format!("{}", address)
+    format!("{:#x}", address)
 }
 
 pub fn get_signer_balance(args: wrap::ArgsGetSignerBalance) -> BigInt {

--- a/wrapper/tests/e2e.spec.ts
+++ b/wrapper/tests/e2e.spec.ts
@@ -216,6 +216,7 @@ describe("Ethereum Wrapper", () => {
       if (!response.ok) throw response.error;
       expect(response.value).toBeDefined();
       expect(response.value?.startsWith("0x")).toBe(true);
+      expect(response.value?.length).toBe(42);
     });
 
     it("getSignerBalance", async () => {


### PR DESCRIPTION
fixed bug where getSignerAddress was returning strings like `"0xabcd...efgh"` instead of the full address.