### PR TITLE
feat: support raw transaction

### DIFF
--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -16,7 +16,7 @@ polywrap-wasm-rs = "0.10.0-pre.10"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93", default-features = false, features = ["raw_value"] }
 ethers-providers = { version = "=1.0.2", features = [] }
-ethers-core = { git="https://github.com/gakonst/ethers-rs", features = ["eip712"] }
+ethers-core = { version = "=1.0.2", features = ["eip712"] }
 ethers-signers = { version = "=1.0.2", features = [] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 

--- a/wrapper/deployment.json
+++ b/wrapper/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmbnAG8iCdVMPQK8tQ5qqFwLKjaLF8BUuuLYiozj7mLF8Y"
+        "result": "wrap://ipfs/QmVh96rJCfCPUbZCwt4SqHcb8tsysVZjJ2iUYA3Ud2uRuc"
       }
     ]
   }

--- a/wrapper/package.json
+++ b/wrapper/package.json
@@ -14,7 +14,7 @@
     "deploy": "npx polywrap deploy -o deployment.json"
   },
   "devDependencies": {
-    "@polywrap/ethereum-provider-js": "0.2.2",
+    "@polywrap/ethereum-provider-js": "0.2.5",
     "@polywrap/client-js": "0.10.0-pre.10",
     "@polywrap/core-js": "0.10.0-pre.10",
     "@polywrap/test-env-js": "0.10.0-pre.10",

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -1,6 +1,5 @@
 use ethers_core::types::{Address, BlockId, BlockNumber, Bytes, H256};
-use ethers_core::abi::{encode_packed, Abi, Function, Token, encode};
-use ethers_core::utils::{keccak256, get_create2_address};
+use ethers_core::abi::{Abi, Function,};
 use polywrap_wasm_rs::{BigInt,JSON};
 use std::str::FromStr;
 
@@ -91,8 +90,8 @@ pub fn sign_message_bytes(args: wrap::ArgsSignMessageBytes) -> String {
 
 pub fn sign_transaction(args: wrap::ArgsSignTransaction) -> String {
     let signer = PolywrapSigner::new(&args.connection);
-    let tx = mapping::from_wrap_request(args.tx);
-    let signature = signer.sign_transaction_sync(&tx).unwrap();
+    let mut tx = mapping::from_wrap_request(args.tx);
+    let signature = signer.sign_transaction_sync(&mut tx).unwrap();
     let bytes: Bytes = signature.to_vec().into();
     format!("{}", bytes).to_string()
 }
@@ -286,46 +285,4 @@ pub fn call_contract_method_and_wait(
     let receipt = provider.get_transaction_receipt_sync(tx_hash).unwrap().unwrap();
     let tx_receipt = mapping::to_wrap_receipt(receipt, 1);
     tx_receipt
-}
-
-pub fn solidity_keccak256_bytes(args: wrap::ArgsSolidityKeccak256Bytes) -> String {
-    let value = Token::Bytes(args.bytes.as_bytes().to_vec());
-    let hash = hex::encode(keccak256(encode(&[value])));
-
-    hash
-}
-
-pub fn encode_bytes_value(args: wrap::ArgsEncodeBytesValue) -> String {
-    let mut bytes: Vec<u8> = Vec::with_capacity(args.value.len());
-    bytes.extend_from_slice(args.value.as_bytes());
-    format!("{}", Bytes::from(bytes)).to_string()
-}
-
-
-pub fn keccak256_bytes(args: wrap::ArgsKeccak256Bytes) -> String {
-    let decoded = Bytes::from_str(&args.bytes).unwrap();
-    let hash = keccak256(decoded);
-    format!("{}", Bytes::from(hash)).to_string()
-}
-
-pub fn keccak256_bytes_encode_packed(args: wrap::ArgsKeccak256BytesEncodePacked) -> String {
-    let bytes = Bytes::from_str(&args.bytes).unwrap();
-    let bytes = Token::Bytes(bytes.to_vec());
-    let encoded = keccak256(encode_packed(&[bytes]).unwrap());
-    format!("{}", Bytes::from(encoded)).to_string()
-}
-
-pub fn generate_create2_address(
-    args: wrap::ArgsGenerateCreate2Address,
-) -> String {
-    let salt = Bytes::from_str(&args.salt).unwrap();
-    let init_code = Bytes::from_str(&args.init_code).unwrap();
-    let address = args.address.parse::<Address>().unwrap();
-    let generated_address = get_create2_address(
-        address,
-        salt,
-        init_code
-    );
-
-    format!("{:?}", generated_address)
 }

--- a/wrapper/src/polywrap_provider/signer.rs
+++ b/wrapper/src/polywrap_provider/signer.rs
@@ -1,4 +1,4 @@
-use crate::wrap::imported::{ArgsAddress, ArgsChainId, ArgsSignMessage, ArgsSignTransaction};
+use crate::wrap::imported::{ArgsAddress, ArgsChainId, ArgsSignMessage, ArgsSignTransaction, ArgsNonce};
 use crate::wrap::{IProviderModule, IProviderConnection, Connection};
 use super::iprovider::get_iprovider;
 use ethers_core::types::{Address, Signature};
@@ -11,9 +11,11 @@ pub struct PolywrapSigner {
     address: Address,
     /// The wallet's chain id (for EIP-155)
     chain_id: u64,
+    // The wallet's nonce
+    nonce: i32,
     /// Ethereum connection to use
-    connection: Option<IProviderConnection>,
-    iprovider: IProviderModule,
+    pub connection: Option<IProviderConnection>,
+    pub iprovider: IProviderModule,
 }
 
 #[derive(Error, Debug)]
@@ -34,7 +36,11 @@ impl PolywrapSigner {
         let address = iprovider.address(&ArgsAddress { connection: iprovider_connection.clone() }).unwrap();
         let chain_id = iprovider.chain_id(&ArgsChainId { connection: iprovider_connection.clone() })
             .expect("failed to obtain signer chain id from provider plugin");
+        let nonce = iprovider.nonce(&ArgsNonce {
+            connection: iprovider_connection.clone()
+        }).unwrap();
         Self {
+            nonce,
             address: Address::from_str(&address).unwrap(),
             chain_id: u64::from_str(&chain_id).unwrap(),
             connection: iprovider_connection,

--- a/wrapper/src/polywrap_provider/sync_signer.rs
+++ b/wrapper/src/polywrap_provider/sync_signer.rs
@@ -1,14 +1,14 @@
 use crate::polywrap_provider::signer::{PolywrapSigner, SignerError};
 use ethers_core::types::{transaction::{eip2718::TypedTransaction,eip712::Eip712}, Signature};
 use ethers_signers::{to_eip155_v};
-
+use crate::imported::ArgsNonce;
 pub trait SyncSigner {
     fn sign_message_sync<S: Send + Sync + AsRef<[u8]>>(
         &self,
         message: S,
     ) -> Result<Signature, SignerError>;
 
-    fn sign_transaction_sync(&self, tx: &TypedTransaction) -> Result<Signature, SignerError>;
+    fn sign_transaction_sync(&self, tx: &mut TypedTransaction) -> Result<Signature, SignerError>;
 
     fn sign_typed_data_sync<T: Eip712 + Send + Sync>(
         &self,
@@ -25,17 +25,26 @@ impl SyncSigner for PolywrapSigner {
         self.sign_bytes(bytes).map_err(|e| SignerError::Eip712Error(e))
     }
 
-    fn sign_transaction_sync(&self, tx: &TypedTransaction) -> Result<Signature, SignerError> {
+    fn sign_transaction_sync(&self, tx: &mut TypedTransaction) -> Result<Signature, SignerError> {
         // rlp must have the same chain id as v in the signature
-        let chain_id = tx.chain_id().map(|id| id.as_u64()).unwrap_or(self.chain_id());
-        let mut tx = tx.clone();
-        tx.set_chain_id(chain_id);
+        if tx.chain_id().is_none(){
+            let chain_id = tx.chain_id().map(|id| id.as_u64()).unwrap_or(self.chain_id());
+            tx.set_chain_id(chain_id);
+        }
+
+        if tx.nonce().is_none() {
+            let nonce = self.iprovider.nonce(&ArgsNonce {
+                connection: self.connection.clone(),
+            }).unwrap();
+            tx.set_nonce(nonce);
+        }
+
         let rlp = tx.rlp().to_vec();
 
         match self.sign_rlp(rlp) {
             Ok(mut sig) => {
                 // sign_hash sets `v` to recid + 27, so we need to subtract 27 before normalizing
-                sig.v = to_eip155_v(sig.v as u8 - 27, chain_id);
+                sig.v = to_eip155_v(sig.v as u8 - 27, tx.chain_id().unwrap().as_u64());
                 Ok(sig)
             },
             Err(e) => Err(SignerError::Eip712Error(e))

--- a/wrapper/src/schema.graphql
+++ b/wrapper/src/schema.graphql
@@ -273,19 +273,6 @@ type Module {
     connection: Connection
   ): String!
 
-  solidityKeccak256Bytes(bytes: String!): String!
-
-  generateCreate2Address(
-    address: String!
-    salt: String!
-    initCode: String!
-  ): String!
-
-  encodeBytesValue(value: String!) : String!
-
-  keccak256BytesEncodePacked(bytes: String!) : String!
-  keccak256Bytes(bytes: String!): String!
-
   signTypedData(
     payload: JSON!
     connection: Connection

--- a/wrapper/tests/e2e.spec.ts
+++ b/wrapper/tests/e2e.spec.ts
@@ -369,62 +369,6 @@ describe("Ethereum Wrapper", () => {
       expect(response.ok).toBeTruthy();
     });
 
-    describe("create 2 address", () => {
-      it("should calculate create 2 address", async () => {
-        const response = await client.invoke<string>({
-          uri,
-          method: "generateCreate2Address",
-          args: {
-            address: "0x1d90fCc0423cCC9650392E799d4d6da9530aCA43",
-            salt: "0x1233388b1647069152c5f8794f8ed87af2edb8cfc397d78e053347bbfe6398b3",
-            initCode: "0x608060405234801561001057600080fd5b506040516101e63803806101e68339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260228152602001806101c46022913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060ab806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea264697066735822122003d1488ee65e08fa41e58e888a9865554c535f2c77126a82cb4c0f917f31441364736f6c63430007060033496e76616c69642073696e676c65746f6e20616464726573732070726f7669646564000000000000000000000000b7f8bc63bbcad18155201308c8f3540b07f84f5e"
-          }
-        });
-        if (!response.ok) throw response.error;
-        expect(response.value).toEqual("0x57d4d0c68057Cc9446F93307082D63466BC3D731".toLowerCase());
-      });
-
-      it.skip("should encode packed", async () => {
-        const response = await client.invoke<string>({
-          uri,
-          method: "wEncodePacked",
-          args: {
-            bytes: "0x2fe2c0ec0d2f63b668a3389b17cfed8ec8554e2cd759b305b8873ea03353a360",
-            uint: "0x0000000000000000000000000000000000000000000000000000000000000042",
-          }
-        });
-        if (!response.ok) throw response.error;
-        expect(response.value).toEqual("0x169b91711c9e5fc8418feaca506caa84243dc031eb336f195d6399e79978f138".toLowerCase());
-     
-      });
-
-      it("should encode bytes and convert to keccak", async () => {
-        const response = await client.invoke<string>({
-          uri,
-          method: "keccak256BytesEncodePacked",
-          args: {
-            bytes: "0x2fe2c0ec0d2f63b668a3389b17cfed8ec8554e2cd759b305b8873ea03353a3600000000000000000000000000000000000000000000000000000000000000042",
-          }
-        });
-        if (!response.ok) throw response.error;
-        expect(response.value).toEqual("0x169b91711c9e5fc8418feaca506caa84243dc031eb336f195d6399e79978f138".toLowerCase());
-     
-      });
-
-      it("should encode keccak256", async () => {
-        const response = await client.invoke<string>({
-          uri,
-          method: "keccak256Bytes",
-          args: {
-            bytes: "0xe1c7392a",
-          }
-        });
-        if (!response.ok) throw response.error;
-        expect(response.value).toEqual("0x2fe2c0ec0d2f63b668a3389b17cfed8ec8554e2cd759b305b8873ea03353a360".toLowerCase());
-     
-      });
-    });
-
     it("toWei", async () => {
       const response = await client.invoke<string>({
         uri,
@@ -526,6 +470,7 @@ describe("Ethereum Wrapper", () => {
       expect(awaitResponse.value.confirmations).toEqual(4);
     });
 
+    // @TODO: Need to add validation of throw when no signer is present in client
     it("sendTransaction", async () => {
       const response = await client.invoke<Schema.TxResponse>({
         uri,


### PR DESCRIPTION
add support of `eth_sendRawTransaction` method for signers that are not wallet. now we are able to support transactions from wallets (like metamask) and also jsonrpc provider + signer (with `new Wallet(..)`) - used mostly in scripts

also, two minor changes:
 - uses the latest version published of `ethers-rs` (instead of fetching it from github, this fixed the problem of `unreachable..`)
 - removes unused utils which have been implementation in to `ethers-utils` wrapper (https://github.com/polywrap/ethereum/pull/35)

blocked by https://github.com/polywrap/ethereum/pull/42