### PR TITLE
eth_singTypedData_v4 non-custom provider argument passing

### DIFF
--- a/provider/implementations/js/src/index.ts
+++ b/provider/implementations/js/src/index.ts
@@ -14,7 +14,7 @@ import { Connections } from "./Connections";
 import {
   eth_encodePacked,
   eth_sendTransaction,
-  eth_signTypedData
+  eth_signTypedData,
 } from "./rpc";
 
 import { PluginFactory, PluginPackage } from "@polywrap/plugin-js";
@@ -54,46 +54,40 @@ export class EthereumProviderPlugin extends Module<ProviderConfig> {
       connection.getSignerType() == SignerType.CUSTOM_SIGNER
     ) {
       const signer = await connection.getSigner();
-      const parameters = eth_sendTransaction.deserializeParameters(
-        paramsStr
-      );
-      const request = eth_sendTransaction.toEthers(
-        parameters[0]
-      );
+      const parameters = eth_sendTransaction.deserializeParameters(paramsStr);
+      const request = eth_sendTransaction.toEthers(parameters[0]);
       const res = await signer.sendTransaction(request);
       return JSON.stringify(res.hash);
     }
 
-    if (
-      args.method === "eth_signTypedData_v4" &&
-      connection.getSignerType() == SignerType.CUSTOM_SIGNER
-    ) {
-      const signer = await connection.getSigner();
-      const parameters = eth_signTypedData.deserializeParameters(
-        paramsStr
-      );
-      let signature = "";
-      // This is a hack because in ethers v5.7 this method is experimental
-      // when we update to ethers v6 this won't be needed. More info:
-      // https://github.com/ethers-io/ethers.js/blob/ec1b9583039a14a0e0fa15d0a2a6082a2f41cf5b/packages/abstract-signer/src.ts/index.ts#L53
-      if ("_signTypedData" in signer) {
-        const [_, data] = parameters
-        const payload = eth_signTypedData.toEthers(data)
-        // @ts-ignore
-        signature = await signer._signTypedData(
-          payload.domain,
-          payload.types,
-          payload.message
-        )
+    if (args.method === "eth_signTypedData_v4") {
+      if (connection.getSignerType() == SignerType.CUSTOM_SIGNER) {
+        const signer = await connection.getSigner();
+        const parameters = eth_signTypedData.deserializeParameters(paramsStr);
+        let signature = "";
+        // This is a hack because in ethers v5.7 this method is experimental
+        // when we update to ethers v6 this won't be needed. More info:
+        // https://github.com/ethers-io/ethers.js/blob/ec1b9583039a14a0e0fa15d0a2a6082a2f41cf5b/packages/abstract-signer/src.ts/index.ts#L53
+        if ("_signTypedData" in signer) {
+          const [_, data] = parameters;
+          const payload = eth_signTypedData.toEthers(data);
+          // @ts-ignore
+          signature = await signer._signTypedData(
+            payload.domain,
+            payload.types,
+            payload.message
+          );
+        }
+        return JSON.stringify(signature);
+      } else {
+        // Metamask expects the payload data as string
+        const params = JSON.parse(paramsStr);
+        const req = await provider.send(args.method, [
+          params[0],
+          JSON.stringify(params[1]),
+        ]);
+        return JSON.stringify(req);
       }
-      return JSON.stringify(signature)
-    } else if (args.method === "eth_signTypedData_v4") {
-      const params = JSON.parse(paramsStr);
-      const req = await provider.send(
-        args.method,
-        [params[0], JSON.stringify(params[1])]
-      );
-      return JSON.stringify(req);
     }
 
     if (args.method === "eth_encodePacked") {
@@ -104,10 +98,7 @@ export class EthereumProviderPlugin extends Module<ProviderConfig> {
 
     const params = JSON.parse(paramsStr);
     try {
-      const req = await provider.send(
-        args.method,
-        params
-      );
+      const req = await provider.send(args.method, params);
       return JSON.stringify(req);
     } catch (err) {
       /**

--- a/provider/implementations/js/src/index.ts
+++ b/provider/implementations/js/src/index.ts
@@ -87,6 +87,13 @@ export class EthereumProviderPlugin extends Module<ProviderConfig> {
         )
       }
       return JSON.stringify(signature)
+    } else if (args.method === "eth_signTypedData_v4") {
+      const params = JSON.parse(paramsStr);
+      const req = await provider.send(
+        args.method,
+        [params[0], JSON.stringify(params[1])]
+      );
+      return JSON.stringify(req);
     }
 
     if (args.method === "eth_encodePacked") {


### PR DESCRIPTION
When using a non-custom signer provider (e.g. Browser) and calling eth_signTypedData_v4, we need to pass payload data as a string.